### PR TITLE
Ensure we always have space for another packet

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -144,7 +144,7 @@ func newLiveCapture(netInterface string, bufferSize int) (*pcap.Handle, error) {
 func (s source) CollectPackets(pb *PacketBuffer) error {
 	pb.Clear()
 	l := pb.PacketCap()
-	for i := 0; i < l; i++ {
+	for i := 0; i < l && pb.BytesRemaining() >= snapLen; i++ {
 		// use ZeroCopyReadPacketData to avoid allocation, even though
 		// we copy the data later
 		buf, ci, err := s.ZeroCopyReadPacketData()
@@ -158,9 +158,6 @@ func (s source) CollectPackets(pb *PacketBuffer) error {
 		// Append makes a copy of the data, which is required because
 		// buf is overwritten on the next call to ZeroCopyReadPacketData.
 		err = pb.Append(PacketData{ci, buf})
-		if err == ErrBytesFull {
-			return nil
-		}
 		if err != nil {
 			return err
 		}

--- a/capture/packetbuffer.go
+++ b/capture/packetbuffer.go
@@ -39,6 +39,11 @@ func (pb *PacketBuffer) bytesStored() int {
 	return pb.offsets[pb.numPackets-1]
 }
 
+// BytesRemaining returns the number of additional bytes this PacketBuffer can hold.
+func (pb *PacketBuffer) BytesRemaining() int {
+	return len(pb.data) - pb.bytesStored()
+}
+
 // Append adds a packet to the PacketBuffer.
 // Makes a copy of pd.Data, which may be modified after Append returns.
 // Returns ErrBytesFull or ErrPacketsFull if there is insufficient space.

--- a/capture/packetbuffer_test.go
+++ b/capture/packetbuffer_test.go
@@ -90,3 +90,25 @@ func TestCorrectSize(t *testing.T) {
 		}
 	}
 }
+
+func TestBytesRemaining(t *testing.T) {
+	l := 100
+	uut := NewPacketBuffer(1, l)
+	if uut.BytesRemaining() != l {
+		t.Fail()
+	}
+	pd := PacketData{
+		Info: gopacket.CaptureInfo{
+			Length:        l,
+			CaptureLength: l,
+		},
+		Data: make([]byte, l),
+	}
+	err := uut.Append(pd)
+	if err != nil {
+		t.Error(err)
+	}
+	if uut.BytesRemaining() != 0 {
+		t.Fail()
+	}
+}

--- a/capture/replay.go
+++ b/capture/replay.go
@@ -55,8 +55,9 @@ func (r *replayer) CollectPackets(pb *PacketBuffer) error {
 		r.dropExpired(elapsed)
 	}
 
+	l := r.buf.PacketLen()
 	writeUntil := r.first.Add(elapsed + replayerTimeout)
-	for ; r.cursor < r.buf.PacketLen(); r.cursor++ {
+	for ; r.cursor < l && pb.BytesRemaining() >= snapLen; r.cursor++ {
 		p := r.buf.Packet(r.cursor)
 		r.received++
 		if p.Info.Timestamp.After(writeUntil) {

--- a/capture/replay_test.go
+++ b/capture/replay_test.go
@@ -55,7 +55,7 @@ func TestPacing(t *testing.T) {
 
 	uut := newReplayer(ts, 1000, 8*1024*1024)
 	uut.Logger = log.ConsoleLogger{}
-	buf := NewPacketBuffer(1000, 1)
+	buf := NewPacketBuffer(1000, 8*1024*1024)
 
 	err := uut.CollectPackets(buf)
 	n := buf.PacketLen()
@@ -86,7 +86,7 @@ func TestDrop(t *testing.T) {
 	ts.AddPacket(start.Add(delay), []byte{1})
 
 	uut := newReplayer(ts, 1000, 8*1024*1024)
-	buf := NewPacketBuffer(1000, 1)
+	buf := NewPacketBuffer(1000, 8*1024*1024)
 
 	err := uut.CollectPackets(buf)
 	n := buf.PacketLen()


### PR DESCRIPTION
If we ran out of space before we ran out of packet slots in a PacketBuffer (which could happen with rather large packets), we would have to handle ErrBytesFull, which complicated error handling. Instead we can avoid even bothering to read a packet if there isn't enough room for a max-size packet in the buffer.