### PR TITLE
Adds logging of data to file in json format

### DIFF
--- a/presentation/json.go
+++ b/presentation/json.go
@@ -1,0 +1,140 @@
+package presentation
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/box/memsniff/analysis"
+	"os"
+	"time"
+)
+
+func (u *uiContext) runLoggingEventLoop() error {
+	updateTick := time.NewTicker(u.interval)
+	defer updateTick.Stop()
+	if err := u.update(); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-updateTick.C:
+			if err := u.updateReport(); err != nil {
+				return err
+			}
+
+		case msg := <-u.msgChan:
+			u.logger.Log(msg)
+		}
+	}
+}
+
+func (u *uiContext) updateReport() error {
+	rep := u.analysis.Report(!u.cumulative)
+	rep.SortBy(-2)
+
+	numKeysSeen := len(rep.Rows)
+	totalBandwidthUsed := totalBytesUseForKeys(rep.Rows)
+
+	s := u.statProvider()
+
+	u.truncateResultsToMaxAndTopX(&rep)
+	u.prevReport = rep
+	numReportedKeys := len(rep.Rows)
+	reportedKeysBandwidth := totalBytesUseForKeys(rep.Rows)
+
+	f, err := u.openFile(u.outputFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	reportJson, _ := formatReportAsJson(u.prevReport, s, numKeysSeen, totalBandwidthUsed,numReportedKeys,reportedKeysBandwidth)
+
+	u.Log(fmt.Sprintf("All_Keys(Bandwidth=%d,Num=%d) Reported_Keys(Bandwidth=%d (%f%%),Num=%d) Incremental(Packets: %d Responses: %d %s) Cumulative(Packets: %d Responses: %d %s)",
+		totalBandwidthUsed, numKeysSeen,
+		reportedKeysBandwidth, 100*float64(reportedKeysBandwidth)/float64(totalBandwidthUsed), numReportedKeys,
+		s.Incremental.PacketsPassedFilter, s.Incremental.ResponsesParsed, u.dropLabel(*s.Incremental),
+		s.Culumative.PacketsPassedFilter, s.Culumative.ResponsesParsed, u.dropLabel(*s.Culumative)))
+
+	if f != nil {
+		// Write to the output file if specified
+		f.WriteString(string(reportJson) + "\n")
+	} else {
+		u.Log(string(reportJson))
+	}
+
+	return nil
+}
+
+func (u *uiContext) openFile(filename string) (*os.File, error) {
+	if filename != "" {
+		f, err := os.OpenFile(u.outputFile, os.O_RDWR|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0644)
+		return f, err
+	} else {
+		return nil, nil
+	}
+}
+
+func formatReportAsJson(report analysis.Report, stats StatsSet, totalKeys int, totalBandwidth int64, reportedKeys int, reportedBandwidth int64) ([]byte, error) {
+	reportMap := map[string]interface{}{}
+	reportMap["ts"] = report.Timestamp.UTC().Unix()
+	reportMap["ts_s"] = report.Timestamp.String()
+	reportMap["totalKeys"] = totalKeys
+	reportMap["totalBandwidth"] = totalBandwidth
+	reportMap["reportedKeys"] = reportedKeys
+	reportMap["reportedBandwidth"] = reportedBandwidth
+	reportMap["reportedBandwidthPercentage"] = 100*float64(reportedBandwidth)/float64(totalBandwidth)
+	reportMap["rows"] = reportToList(report)
+	reportMap["stats"] = statsSetToMap(stats)
+	return json.Marshal(reportMap)
+}
+
+func reportToList(report analysis.Report) []map[string]interface{} {
+	reportList := make([]map[string]interface{}, len(report.Rows))
+	for idx, row := range report.Rows {
+		reportList[idx] = reportRowToMap(row, report.KeyColNames, report.ValColNames)
+	}
+	return reportList
+}
+
+func reportRowToMap(reportRow analysis.ReportRow, keyColNames []string, valueColNames []string) map[string]interface{} {
+	rowMap := map[string]interface{}{}
+
+	for idx, keyCol := range keyColNames {
+		rowMap[keyCol] = reportRow.Key[idx]
+	}
+
+	for idx, valueCol := range valueColNames {
+		rowMap[valueCol] = reportRow.Values[idx]
+	}
+
+	return rowMap
+}
+
+func statsSetToMap(stats StatsSet) map[string]interface{} {
+	statsSetMap := map[string]interface{}{}
+	statsSetMap["incremental"] = statsToMap(*stats.Incremental)
+	return statsSetMap
+}
+
+func statsToMap(stats Stats) map[string]interface{} {
+	statsMap := map[string]interface{}{}
+	statsMap["PacketsEnteredFilter"] = stats.PacketsEnteredFilter
+	statsMap["PacketsPassedFilter"] = stats.PacketsPassedFilter
+	statsMap["PacketsCaptured"] = stats.PacketsCaptured
+	statsMap["PacketsDroppedKernel"] = stats.PacketsDroppedKernel
+	statsMap["PacketsDroppedParser"] = stats.PacketsDroppedParser
+	statsMap["PacketsDroppedAnalysis"] = stats.PacketsDroppedAnalysis
+	statsMap["PacketsDroppedTotal"] = stats.PacketsDroppedTotal
+	statsMap["ResponsesParsed"] = stats.ResponsesParsed
+	return statsMap
+}
+
+// Given a slice of rows, return the sum of the sum(size) columns
+func totalBytesUseForKeys(rows []analysis.ReportRow) int64 {
+	total := int64(0)
+	for _,r := range rows {
+		total = total + r.Values[1]
+	}
+	return total
+}

--- a/presentation/json.go
+++ b/presentation/json.go
@@ -86,7 +86,7 @@ func formatReportAsJson(report analysis.Report, stats StatsSet, totalKeys int, t
 	}
 
 	return JsonReport{
-		Timestamp:                   report.Timestamp.Format("2006-01-02T15:04:05-0700"),
+		Timestamp:                   report.Timestamp.Format(time.RFC3339),
 		TotalKeys:                   totalKeys,
 		TotalBandwidth:              totalBandwidth,
 		ReportedKeys:                len(report.Rows),

--- a/presentation/presentation.go
+++ b/presentation/presentation.go
@@ -108,7 +108,7 @@ func (u uiContext) Log(items ...interface{}) {
 
 func (u *uiContext) truncateResultsToMaxAndTopX(rep *analysis.Report) {
 	repRows := rep.Rows
-	i := -1
+	i := 0
 	for n, r := range repRows {
 		if r.Values[1] >= int64(u.minKeySizeThreshold) && n < int(u.topX) {
 			i++
@@ -117,5 +117,5 @@ func (u *uiContext) truncateResultsToMaxAndTopX(rep *analysis.Report) {
 		}
 	}
 
-	rep.Rows = repRows[:(i + 1)]
+	rep.Rows = repRows[:(i)]
 }

--- a/presentation/presentation.go
+++ b/presentation/presentation.go
@@ -19,42 +19,56 @@ type UIHandler interface {
 }
 
 type uiContext struct {
-	logger       log.Logger
-	analysis     *analysis.Pool
-	interval     time.Duration
-	statProvider StatProvider
-	messages     []string
-	msgChan      chan string
-	prevReport   analysis.Report
-	cumulative   bool
-	paused       bool
-	useGui       bool
-	topX         uint16
-	maxVal       uint64
-	outputFile   string
+	logger              log.Logger
+	analysis            *analysis.Pool
+	interval            time.Duration
+	statProvider        StatProvider
+	messages            []string
+	msgChan             chan string
+	prevReport          analysis.Report
+	cumulative          bool
+	paused              bool
+	useTermbox          bool
+	topX                uint16
+	minKeySizeThreshold uint64
+	outputFile          string
 }
 
 type StatsSet struct {
-	Culumative	*Stats
+	Culumative  *Stats
 	Incremental *Stats
 }
 
 // Stats collects statistics on runtime performance to be displayed to the user.
 type Stats struct {
 	// count of packets that entered the kernel BPF
-	PacketsEnteredFilter int
+	PacketsEnteredFilter int `json:"PacketsEnteredFilter"`
 	// count of packets that passed the BPF and queued or dropped by the kernel
-	PacketsPassedFilter int
+	PacketsPassedFilter int `json:"PacketsPassedFilter"`
 	// count of packets received from pcap
-	PacketsCaptured int
+	PacketsCaptured int `json:"PacketsCaptured"`
 	// count of packets dropped due to kernel buffer overflow
-	PacketsDroppedKernel int
+	PacketsDroppedKernel int `json:"PacketsDroppedKernel"`
 	// count of packets dropped due to no decoder available
-	PacketsDroppedParser int
+	PacketsDroppedParser int `json:"PacketsDroppedParser"`
 	// count of packets dropped due to analysis queue being full
-	PacketsDroppedAnalysis int
-	PacketsDroppedTotal    int
-	ResponsesParsed        int
+	PacketsDroppedAnalysis int `json:"PacketsDroppedAnalysis"`
+	PacketsDroppedTotal    int `json:"PacketsDroppedTotal"`
+	ResponsesParsed        int `json:"ResponsesParsed"`
+}
+
+// Subtracts other from these original set of stats, returning a new Stats
+func (s Stats) Diff(other Stats) Stats {
+	newStats := s
+	newStats.PacketsEnteredFilter = s.PacketsEnteredFilter - other.PacketsEnteredFilter
+	newStats.PacketsPassedFilter = s.PacketsPassedFilter - other.PacketsPassedFilter
+	newStats.PacketsCaptured = s.PacketsCaptured - other.PacketsCaptured
+	newStats.PacketsDroppedKernel = s.PacketsDroppedKernel - other.PacketsDroppedKernel
+	newStats.PacketsDroppedParser = s.PacketsDroppedParser - other.PacketsDroppedParser
+	newStats.PacketsDroppedAnalysis = s.PacketsDroppedAnalysis - other.PacketsDroppedAnalysis
+	newStats.PacketsDroppedTotal = s.PacketsDroppedTotal - other.PacketsDroppedTotal
+	newStats.ResponsesParsed = s.ResponsesParsed - other.ResponsesParsed
+	return newStats
 }
 
 // StatProvider returns a snapshot of current runtime statistics.
@@ -62,26 +76,26 @@ type StatProvider func() StatsSet
 
 // New returns a UIHandler that is ready to run
 func New(logger log.Logger, analysisPool *analysis.Pool, interval time.Duration, cumulative bool, statProvider StatProvider,
-		useGui bool, topX uint16, maxVal uint64, outputFile string) UIHandler {
+	useTermbox bool, topX uint16, minKeySizeThreshold uint64, outputFile string) UIHandler {
 
 	return &uiContext{
-		logger:		  logger,
-		analysis:     analysisPool,
-		interval:     interval,
-		statProvider: statProvider,
-		msgChan:      make(chan string, 128),
-		prevReport:   analysis.Report{},
-		cumulative:   cumulative,
-		paused:       false,
-		useGui:       useGui,
-		topX:         topX,
-		maxVal:       maxVal,
-		outputFile:   outputFile,
+		logger:              logger,
+		analysis:            analysisPool,
+		interval:            interval,
+		statProvider:        statProvider,
+		msgChan:             make(chan string, 128),
+		prevReport:          analysis.Report{},
+		cumulative:          cumulative,
+		paused:              false,
+		useTermbox:          useTermbox,
+		topX:                topX,
+		minKeySizeThreshold: minKeySizeThreshold,
+		outputFile:          outputFile,
 	}
 }
 
 func (u uiContext) Run() error {
-	if(u.useGui) {
+	if u.useTermbox {
 		return u.runTermbox()
 	} else {
 		return u.runLoggingEventLoop()
@@ -96,18 +110,12 @@ func (u *uiContext) truncateResultsToMaxAndTopX(rep *analysis.Report) {
 	repRows := rep.Rows
 	i := -1
 	for n, r := range repRows {
-		if r.Values[1] >= int64(u.maxVal) && n < int(u.topX) {
+		if r.Values[1] >= int64(u.minKeySizeThreshold) && n < int(u.topX) {
 			i++
 		} else {
 			break
 		}
 	}
 
-	if i >= 0 {
-		rep.Rows = repRows[:(i+1)]
-	} else {
-		rep.Rows = []analysis.ReportRow{}
-	}
-
+	rep.Rows = repRows[:(i + 1)]
 }
-

--- a/version.go
+++ b/version.go
@@ -15,7 +15,7 @@
 package main
 
 // Version is the release version of memsniff.
-const Version = "1.4.0"
+const Version = "1.5.0"
 
 // GitRevision holds the HEAD revision when building memsniff.
 var GitRevision = "autopopulated by build.sh"


### PR DESCRIPTION
This commit adds logging of data to file in json format in addition to the existing top like interface.

In addition to this, there are 2 new flags which may be specified
--top N       "Only include the top N rows in the report"
--threshold N "Only include data where the sum(size) of the key is greater than N"

Following is an example of the json which is generated (reformatted for readability):

```
{
  "reportedBandwidth": 9968640,
  "reportedBandwidthPercentage": 88.9041095890411,
  "reportedKeys": 5,
  "rows": [
    {
      "key": "test_a",
      "max(size)": 1024,
      "sum(size)": 9286656
    },
    {
      "key": "test_t",
      "max(size)": 20480,
      "sum(size)": 184320
    },
    {
      "key": "test_s",
      "max(size)": 19456,
      "sum(size)": 175104
    },
    {
      "key": "test_r",
      "max(size)": 18432,
      "sum(size)": 165888
    },
    {
      "key": "test_q",
      "max(size)": 17408,
      "sum(size)": 156672
    }
  ],
  "stats": {
    "incremental": {
      "PacketsCaptured": 37000,
      "PacketsDroppedAnalysis": 0,
      "PacketsDroppedKernel": 0,
      "PacketsDroppedParser": 0,
      "PacketsDroppedTotal": 0,
      "PacketsEnteredFilter": 36765,
      "PacketsPassedFilter": 37000,
      "ResponsesParsed": 9240
    }
  },
  "totalBandwidth": 11212800,
  "totalKeys": 20,
  "ts": 1578558411,
  "ts_s": "2020-01-09 00:26:51.639704 -0800 PST m=+23.108533705"
}
```